### PR TITLE
Add new setting "StopDelay"

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="service.fhemcinema"
 	name="Home Cinema Automation"
-	version="0.3.0"
-	provider-name="Leo Moll">
+	version="0.3.1"
+	provider-name="Leo Moll,Memphiz">
 	<requires>
 		<import addon="xbmc.python" version="2.1.0"/>
 	</requires>

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+0.3.1
+- Added option for delaying the Video/Audio stopped command
+
 0.3.0
 - Added copyright notice of the plugin logo (The plugin logo is under copyright by bytefeed.com)
 

--- a/resources/language/English/strings.xml
+++ b/resources/language/English/strings.xml
@@ -17,4 +17,5 @@
 	<string id="30037">Audio Paused</string>
 	<string id="30038">Audio Stopped</string>
 	<string id="30039">System variable</string>
+	<string id="30040">Delay command on Video/Audio Stopped</string>
 </strings>

--- a/resources/language/German/strings.xml
+++ b/resources/language/German/strings.xml
@@ -17,4 +17,5 @@
 	<string id="30037">Audio in Pause</string>
 	<string id="30038">Audio gestoppt</string>
 	<string id="30039">Systemvariable</string>
+	<string id="30040">Befehl bei Video/Audio gestoppt verzögern</string>
 </strings>

--- a/resources/language/Italian/strings.xml
+++ b/resources/language/Italian/strings.xml
@@ -17,4 +17,5 @@
 	<string id="30037">Audio in pausa</string>
 	<string id="30038">Audio terminato</string>
 	<string id="30039">Variabile di sistema</string>
+	<string id="30040">Delay command on Video/Audio Stopped</string>
 </strings>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -4,6 +4,7 @@
 		<setting id="endpointtype"		type="labelenum"	label="30010"	default="FHEM"	values="FHEM|CCU"	/>
 		<setting id="hostname"			type="text"			label="30011"	default=""							/>
 		<setting id="port"				type="number"		label="30012"	default="7072"	visible="eq(-2,0)"	/>
+		<setting id="stopdelay"                      type="slider" label="30040" default="0" range="0,30" />
 		<setting						type="lsep"			label="30013"										/>
 		<setting id="onstartup"			type="text"			label="30031"	default=""		visible="eq(-4,0)"	/>
 		<setting id="onshutdown"		type="text"			label="30032"	default=""		visible="eq(-5,0)"	/>


### PR DESCRIPTION
While playing with the CinemaVision addon i found a problem as follows.

I have configured the Home Cinema Automation addon to switch on my lights when playback stops. The CinemaVision addon plays multiple trailers and video bumpers before starting the actual movie. This leads to sort of light on, off, on, off situation.

This pull request adds a setting which allows to delay the execution of the stop command. This prevents the flicker and only executes that command if the movie was stopped for the given time.

Defaults to zero so this is backward compatible behavior.

I also did a pull request to the official kodi repo with this chanage ( and that includes your 0.3.0 change aswell...):

If you are fine with this change please sign off the pull request for the repo aswell:
https://github.com/xbmc/repo-scripts/pull/493

Thx :)