### PR TITLE
Python3

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -18,7 +18,7 @@
 # -- Imports ------------------------------------------------
 import datetime,socket,subprocess,os
 import xbmc,xbmcplugin,xbmcgui,xbmcaddon
-import httplib
+import http.client
 import time
 
 # -- Constants ----------------------------------------------
@@ -85,7 +85,7 @@ class FhemHandler( xbmc.Player ):
 			xbmc.log ('Sending command to FHEM: '+command)
 			s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 			s.connect((settings.getSetting('hostname'), int(settings.getSetting('port'))))
-			s.send('\n{0}\nexit\n'.format(command))
+			s.send('\n{0}\nexit\n'.format(command).encode())
 			s.close()
 
 	def SendCCU(self,command):
@@ -112,7 +112,7 @@ class FhemHandler( xbmc.Player ):
 				state = 8
 			else:
 				state = 0
-			connection = httplib.HTTPConnection(hostname,8181,timeout=10)
+			connection = http.client.HTTPConnection(hostname,8181,timeout=10)
 			connection.connect();
 			connection.set_debuglevel(9);
 			params = 'v1=dom.GetObject(\"'+ccusystemvar+'\").State(\"' + str(state) + '\");';
@@ -124,7 +124,8 @@ class FhemHandler( xbmc.Player ):
 			xbmc.log ('No CCU Object configured')
 
 	def Run(self):
-		while(not xbmc.abortRequested):
+		monitor = xbmc.Monitor()
+		while(not monitor.abortRequested()):
 			if xbmc.Player().isPlaying():
 				if xbmc.Player().isPlayingVideo():
 					self.isplayingvideo = True

--- a/addon.py
+++ b/addon.py
@@ -64,6 +64,13 @@ class FhemHandler( xbmc.Player ):
 			xbmc.log( 'Cinema: Exception in isDayTime: ' + str( e ), xbmc.LOGERROR )
 			return False
 
+	def isLiveTv( self ):
+		try:
+			file = self.getPlayingFile()
+			return self.isplayingvideo and file.find("pvr://") > -1
+		except:
+			return False
+
 	def getCommand( self, command ):
 		if settings.getSetting( 'daytimeenable' ) == "true":
 			if self.isDayTime():
@@ -71,6 +78,9 @@ class FhemHandler( xbmc.Player ):
 		return settings.getSetting(command)
 
 	def SendCommand(self,command):
+		if settings.getSetting( 'ignorelivetv' ) == "true" and self.isLiveTv():
+			xbmc.log('suppressing fhem command due to livetv')
+			return
 		endpointtype=settings.getSetting('endpointtype')
 		if type(endpointtype) is str and endpointtype == "FHEM":
 			self.SendFHEM(self.getCommand(command))

--- a/addon.xml
+++ b/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="service.fhemcinema"
 	name="Home Cinema Automation"
-	version="0.3.3"
+	version="0.4.0"
 	provider-name="Leo Moll, Memphiz">
 	<requires>
 		<import addon="xbmc.python" version="3.0.0"/>
@@ -18,11 +18,14 @@
 		<description lang="de">Diese Erweiterung erlaubt die Steuerung der Beleuchtung und anderer Geräte über den Heim-Automatisierungsserver FHEM oder mittels Homematic CCU. Die Rechte am Plugin Logo liegen bei bytefeed.com. Vielen Dank für die Nutzungserlaubnis.</description>
 		<description lang="en">This extension allows to control lights and other devices by sending commands on various player actions to the home automation system FHEM or to a Homematic CCU. The plugin logo is under copyright by bytefeed.com. Thank you for the kind permission of use!</description>
 		<description lang="it">Quest'estensione permette il controllo delle luci e di altri dispositivi mediante il sistema di automazione casalinga FHEM o Homematic CCU. I diritti d'autore del logo appartengono a bytefeed.com. Ringraziamo per il permesso d'uso.</description>
-		<news>v0.3.4 (2018-01-XX):
+		<news>v0.4.0 (2023-11-XX):
+- added python3 support
+- allow to ignore events in case live tv is played back
+v0.3.4 (2018-01-XX):
 - Fixed broken localisation
 v0.3.3 (2017-12-25):
 - Fixed broken settings (Closes #4)
-- Adapted to new language system
+- Adapted to new language system</news>
 		<platform>all</platform>
 		<language></language>
 		<license>GNU GENERAL PUBLIC LICENSE. Version 2, June 1991</license>

--- a/addon.xml
+++ b/addon.xml
@@ -4,7 +4,7 @@
 	version="0.3.3"
 	provider-name="Leo Moll, Memphiz">
 	<requires>
-		<import addon="xbmc.python" version="2.1.0"/>
+		<import addon="xbmc.python" version="3.0.0"/>
 	</requires>
 	<extension
 		point="xbmc.service"

--- a/addon.xml
+++ b/addon.xml
@@ -18,14 +18,6 @@
 		<description lang="de">Diese Erweiterung erlaubt die Steuerung der Beleuchtung und anderer Geräte über den Heim-Automatisierungsserver FHEM oder mittels Homematic CCU. Die Rechte am Plugin Logo liegen bei bytefeed.com. Vielen Dank für die Nutzungserlaubnis.</description>
 		<description lang="en">This extension allows to control lights and other devices by sending commands on various player actions to the home automation system FHEM or to a Homematic CCU. The plugin logo is under copyright by bytefeed.com. Thank you for the kind permission of use!</description>
 		<description lang="it">Quest'estensione permette il controllo delle luci e di altri dispositivi mediante il sistema di automazione casalinga FHEM o Homematic CCU. I diritti d'autore del logo appartengono a bytefeed.com. Ringraziamo per il permesso d'uso.</description>
-		<news>v0.4.0 (2023-11-XX):
-- added python3 support
-- allow to ignore events in case live tv is played back
-v0.3.4 (2018-01-XX):
-- Fixed broken localisation
-v0.3.3 (2017-12-25):
-- Fixed broken settings (Closes #4)
-- Adapted to new language system</news>
 		<platform>all</platform>
 		<language></language>
 		<license>GNU GENERAL PUBLIC LICENSE. Version 2, June 1991</license>

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+0.4.0
+- added python3 support
+- allow to ignore events in case live tv is played back
+
 0.3.3
 - Fixed broken settings (Closes #4)
 - Adapted to new language system

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -91,3 +91,7 @@ msgstr "Audio Stopped"
 msgctxt "#30039"
 msgid "System variable"
 msgstr "System variable"
+
+msgctxt "#30040"
+msgid "Ignore LiveTV"
+msgstr "Ignore LiveTV"

--- a/resources/language/German/strings.po
+++ b/resources/language/German/strings.po
@@ -90,3 +90,7 @@ msgstr "Audiowiedergabe beendet"
 msgctxt "#30039"
 msgid "System variable"
 msgstr "Systemvariable"
+
+msgctxt "#30040"
+msgid "Ignore LiveTV"
+msgstr "Ignoriere TV"

--- a/resources/language/Italian/strings.po
+++ b/resources/language/Italian/strings.po
@@ -90,3 +90,7 @@ msgstr "Audio finito"
 msgctxt "#30039"
 msgid "System variable"
 msgstr "Variabile di sistema"
+
+msgctxt "#30040"
+msgid "Ignore LiveTV"
+msgstr "Ignorare la televisione"

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -5,16 +5,17 @@
 		<setting id="hostname"			type="text"			label="30011"	default=""							/>
 		<setting id="port"				type="number"		label="30012"	default="7072"	visible="eq(-2,0)"	/>
 		<setting id="stopdelay"			type="slider"		label="30013"	default="0"		range="0,30"		/>
+		<setting id="ignorelivetv"		type="bool"		label="30040"	default="false"	/>
 		<setting						type="lsep"			label="30014"										/>
-		<setting id="onstartup"			type="text"			label="30031"	default=""		visible="eq(-5,0)"	/>
-		<setting id="onshutdown"		type="text"			label="30032"	default=""		visible="eq(-6,0)"	/>
-		<setting id="onvideoplay"		type="text"			label="30033"	default=""		visible="eq(-7,0)"	/>
-		<setting id="onvideopause"		type="text"			label="30034"	default=""		visible="eq(-8,0)"	/>
-		<setting id="onvideostop"		type="text"			label="30035"	default=""		visible="eq(-9,0)"	/>
-		<setting id="onaudioplay"		type="text"			label="30036"	default=""		visible="eq(-10,0)"	/>
-		<setting id="onaudiopause"		type="text"			label="30037"	default=""		visible="eq(-11,0)"	/>
-		<setting id="onaudiostop"		type="text"			label="30038"	default=""		visible="eq(-12,0)"	/>
-		<setting id="ccusystemvar"		type="text"			label="30039"	default=""		visible="eq(-13,1)"	/>
+		<setting id="onstartup"			type="text"			label="30031"	default=""		visible="eq(-6,0)"	/>
+		<setting id="onshutdown"		type="text"			label="30032"	default=""		visible="eq(-7,0)"	/>
+		<setting id="onvideoplay"		type="text"			label="30033"	default=""		visible="eq(-8,0)"	/>
+		<setting id="onvideopause"		type="text"			label="30034"	default=""		visible="eq(-9,0)"	/>
+		<setting id="onvideostop"		type="text"			label="30035"	default=""		visible="eq(-10,0)"	/>
+		<setting id="onaudioplay"		type="text"			label="30036"	default=""		visible="eq(-11,0)"	/>
+		<setting id="onaudiopause"		type="text"			label="30037"	default=""		visible="eq(-12,0)"	/>
+		<setting id="onaudiostop"		type="text"			label="30038"	default=""		visible="eq(-13,0)"	/>
+		<setting id="ccusystemvar"		type="text"			label="30039"	default=""		visible="eq(-14,1)"	/>
 	</category>
 	<category label="30002">
 		<setting id="daytimeenable"		type="bool"		label="30021"	default="false"	/>


### PR DESCRIPTION
Add python 3 support and an option for ignoring live tv.
If this is ok with you I would PR this to the matrix branch of the official repo to have a working version of this adding available again (was last published to Gotham branch and stopped working as of matrix because of python3 becoming mandatory)